### PR TITLE
add POSIX header

### DIFF
--- a/sandbar.c
+++ b/sandbar.c
@@ -16,6 +16,10 @@
 #include <wayland-cursor.h>
 #include <wayland-util.h>
 
+#ifdef __unix__
+#include <unistd.h>
+#endif
+
 #include "utf8.h"
 #include "xdg-shell-protocol.h"
 #include "xdg-output-unstable-v1-protocol.h"


### PR DESCRIPTION
This fixes the building process for systems that don't rely on `glibc`. Without specifying this header the build will result in error: `'STDIN_FILENO' undeclared`.