### PR TITLE
Add DESTDIR variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	$(RM) $(BINS) $(addsuffix .o,$(BINS))
 
 install: all
-	install -D -t $(PREFIX)/bin $(BINS)
+	install -D -t $(DESTDIR)$(PREFIX)/bin $(BINS)
 
 WAYLAND_PROTOCOLS=$(shell pkg-config --variable=pkgdatadir wayland-protocols)
 WAYLAND_SCANNER=$(shell pkg-config --variable=wayland_scanner wayland-scanner)


### PR DESCRIPTION
Adds $DESTDIR variable in `Makefile` which [facilitates packaging](http://www.chiark.greenend.org.uk/doc/make-doc/make.html/Makefile-Conventions.html#DESTDIR).