### PR TITLE
When the Bar structure is released, the pointer under the Seat struct…

### DIFF
--- a/sandbar.c
+++ b/sandbar.c
@@ -990,6 +990,12 @@ handle_global(void *data, struct wl_registry *registry,
 static void
 teardown_bar(Bar *bar)
 {
+    Seat *seat;
+    wl_list_for_each(seat, &seat_list, link) {
+        if (seat->bar == bar) {
+            seat->bar = NULL;
+        }
+    }
 	if (bar->title)
 		free(bar->title);
 	if (bar->layout)


### PR DESCRIPTION
# environment
kernel version: 6.16.3-arch1-1 in archlinux
gcc: 15.2.1

# problem
 When the Bar structure is released, the pointer under the Seat structure is not properly cleared, triggering a dangling. This triggers a double free and causes the program to exit abnormally. This issue is likely to allow attackers to construct a malicious attack chain by simulating Wayland signals to allocate memory space at a fixed time and use double free to hijack control flow. This operation is often seen in CTF Pwn competitions.

# Specific process
in `sandbar.c`
```c
static void
handle_global_remove(void *data, struct wl_registry *registry, uint32_t name)
{
	Bar *bar;
	Seat *seat;
	wl_list_for_each(bar, &bar_list, link) {
		if (bar->registry_name == name) {
			wl_list_remove(&bar->link);
			teardown_bar(bar);
			return;
		}
	}
...
// This will result in the release of bar, but no processing of the seat pointer
static void
teardown_bar(Bar *bar)
{
        ...
	free(bar);
}
// The seat structure contains bar
typedef struct {
        ....
	Bar *bar;
        .....
} Seat;

```
Then, when it comes to another function, there will be a dangling pointer access problem, and this dangling pointer is very easy to be maliciously constructed by an attacker.
```c
static void
river_seat_status_focused_view(void *data, struct zriver_seat_status_v1 *seat_status,
			       const char *title)
{
	if (no_title)
		return;
	
	Seat *seat = (Seat *)data;

	if (!seat->bar)
		return;
	if (seat->bar->title)
		free(seat->bar->title);
	if (!(seat->bar->title = strdup(title)))
		EDIE("strdup");
	seat->bar->redraw = true;
}
```
# How i found it
Since the company doesn't allow the use of personal laptops, I tried closing it and hiding it in my backpack. When I opened it again, I found that Sandbar was abnormally closed. I thought there seemed to be some problems. So I re-downloaded the source code and compiled it with sanitize. When I tried to reproduce the problem, I got the following error:
```c
❯ ./sandbar
=================================================================
==501952==ERROR: AddressSanitizer: attempting double-free on 0x7b7238c289f0 in thread T0:
    #0 0x7f523a71f79d in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x55fc370c3fde in river_seat_status_focused_view /home/peiwithhao/repo/sandbar/sandbar.c:866
    #2 0x7f523a43eac5  (/usr/lib/libffi.so.8+0x7ac5) (BuildId: 02fec367864097384b082accc299b6e74c83454b)
    #3 0x7f523a43b76a  (/usr/lib/libffi.so.8+0x476a) (BuildId: 02fec367864097384b082accc299b6e74c83454b)
    #4 0x7f523a43e06d in ffi_call (/usr/lib/libffi.so.8+0x706d) (BuildId: 02fec367864097384b082accc299b6e74c83454b)
    #5 0x7f523ad5548c  (/usr/lib/libwayland-client.so.0+0x448c) (BuildId: 3b07142880be2014296cc8464e4410c69ed78d0d)
    #6 0x7f523ad562e8  (/usr/lib/libwayland-client.so.0+0x52e8) (BuildId: 3b07142880be2014296cc8464e4410c69ed78d0d)
    #7 0x7f523ad566f2 in wl_display_dispatch_queue_pending (/usr/lib/libwayland-client.so.0+0x56f2) (BuildId: 3b07142880be2014296cc8464e4410c69ed78d0d)
    #8 0x7f523ad59f33 in wl_display_dispatch_queue_timeout (/usr/lib/libwayland-client.so.0+0x8f33) (BuildId: 3b07142880be2014296cc8464e4410c69ed78d0d)
    #9 0x7f523ad5a00f in wl_display_dispatch_queue (/usr/lib/libwayland-client.so.0+0x900f) (BuildId: 3b07142880be2014296cc8464e4410c69ed78d0d)
    #10 0x55fc370c5279 in event_loop /home/peiwithhao/repo/sandbar/sandbar.c:1215
    #11 0x55fc370c671f in main /home/peiwithhao/repo/sandbar/sandbar.c:1401
    #12 0x7f523a227674  (/usr/lib/libc.so.6+0x27674) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)
    #13 0x7f523a227728 in __libc_start_main (/usr/lib/libc.so.6+0x27728) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)
    #14 0x55fc370c1414 in _start (/home/peiwithhao/repo/sandbar/sandbar+0x7414) (BuildId: 7a7fa7fd2f1a9bf36cada2b41a2c6029a964930c)

0x7b7238c289f0 is located 0 bytes inside of 10-byte region [0x7b7238c289f0,0x7b7238c289fa)
freed by thread T0 here:
    #0 0x7f523a71f79d in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x55fc370c47b0 in teardown_bar /home/peiwithhao/repo/sandbar/sandbar.c:994
    #2 0x55fc370c4924 in handle_global_remove /home/peiwithhao/repo/sandbar/sandbar.c:1031
    #3 0x7f523a43eac5  (/usr/lib/libffi.so.8+0x7ac5) (BuildId: 02fec367864097384b082accc299b6e74c83454b)

previously allocated by thread T0 here:
    #0 0x7f523a71a42a in strdup /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:593
    #1 0x55fc370c3ff2 in river_seat_status_focused_view /home/peiwithhao/repo/sandbar/sandbar.c:867
    #2 0x7f523a43eac5  (/usr/lib/libffi.so.8+0x7ac5) (BuildId: 02fec367864097384b082accc299b6e74c83454b)

SUMMARY: AddressSanitizer: double-free /home/peiwithhao/repo/sandbar/sandbar.c:866 in river_seat_status_focused_view
==501952==ABORTING
```
This is because the dangling pointer of seat->bar still exists, so we continue to try to release seat->bar->title
```c
static void
teardown_bar(Bar *bar)
{
	if (bar->title)
		free(bar->title);
	if (bar->layout)
		free(bar->layout);
        ....
}
static void
river_seat_status_focused_view(void *data, struct zriver_seat_status_v1 *seat_status,
			       const char *title)
{
	if (no_title)
		return;
	
	Seat *seat = (Seat *)data;

	if (!seat->bar)
		return;
        // Here! :)
	if (seat->bar->title)
		free(seat->bar->title);
	if (!(seat->bar->title = strdup(title)))
		EDIE("strdup");
	seat->bar->redraw = true;
}

```
I later verified this by debugging with gdb
```
──────────────────────────────────────────[ SOURCE (CODE) ]───────────────────────────────────────────
In file: /home/peiwithhao/repo/sandbar/sandbar.c:863
   858         if (no_title)
   859                 return;
   860         
   861         Seat *seat = (Seat *)data;
   862 
 ► 863         if (!seat->bar)
   864                 return;
   865         if (seat->bar->title)
   866                 free(seat->bar->title);
   867         if (!(seat->bar->title = strdup(title)))
   868                 EDIE("strdup");
──────────────────────────────────────────────[ STACK ]───────────────────────────────────────────────
00:0000│ rsp 0x7fffffffd810 —▸ 0x7fffffffd850 —▸ 0x7fffffffd860 ◂— 0
01:0008│-038 0x7fffffffd818 —▸ 0x7d0ff5dfec5c ◂— 0
02:0010│-030 0x7fffffffd820 —▸ 0x7c7ff5df31a0 —▸ 0x555555567920 (zriver_seat_status_v1_interface) —▸ 0x555555564280 ◂— 'zriver_seat_status_v1'
03:0018│-028 0x7fffffffd828 —▸ 0x7c6ff5de0020 —▸ 0x7c7ff5de0420 —▸ 0x555555567c60 (wl_seat_interface) —▸ 0x7ffff7f761f7 ◂— ...
04:0020│-020 0x7fffffffd830 —▸ 0x7c7ff5de0120 —▸ 0x555555567c20 (wl_registry_interface) —▸ 0x7ffff7f76256 ◂— 'wl_registry'
05:0028│-018 0x7fffffffd838 —▸ 0x7c6ff5de0020 —▸ 0x7c7ff5de0420 —▸ 0x555555567c60 (wl_seat_interface) —▸ 0x7ffff7f761f7 ◂— ...
06:0030│-010 0x7fffffffd840 —▸ 0x7ccff5de0110 ◂— 0x653
07:0038│-008 0x7fffffffd848 —▸ 0x7fffffffda48 —▸ 0x7c7ff5df31a0 —▸ 0x555555567920 (zriver_seat_status_v1_interface) —▸ 0x555555564280 ◂— ...
────────────────────────────────────────────[ BACKTRACE ]─────────────────────────────────────────────
 ► 0   0x55555555dfa9 river_seat_status_focused_view+44
   1   0x7ffff7f17ac6 ffi_call_unix64+86
   2   0x7ffff7f1476b ffi_call_int.lto_priv+507
   3   0x7ffff7f1706e ffi_call+302
   4   0x7ffff7f6f48d wl_closure_invoke.constprop+365
   5   0x7ffff7f702e9 dispatch_event+457
   6   0x7ffff7f706f3 wl_display_dispatch_queue_pending+115
   7   0x7ffff7f706f3 wl_display_dispatch_queue_pending+115
──────────────────────────────────────────────────────────────────────────────────────────────────────
pwndbg> p seat
$1 = (Seat *) 0x7c6ff5de0020
pwndbg> p *seat
$2 = {
  wl_seat = 0x7c7ff5de0420,
  wl_pointer = 0x7c7ff5df3320,
  river_seat_status = 0x7c7ff5df31a0,
  registry_name = 39,
  bar = 0x7ccff5de0110,
  hovering = false,
  pointer_x = 0,
  pointer_y = 0,
  pointer_button = 0,
  mode = 0x7c1ff5e289d0 "normal",
  link = {
    prev = 0x55555556ae60 <seat_list>,
    next = 0x55555556ae60 <seat_list>
  }
}
pwndbg> x/20gx seat->bar
0x7ccff5de0110:	0x0000000000000653	0x00007c7ff5df30a0
0x7ccff5de0120:	0x00007c7ff5df3120	0x00007c7ff5df3020
0x7ccff5de0130:	0x000000000000005b	0x00007c1ff5e28730
```
You can see that the actual content does not quite match the data type of the bar structure.
# Repair method
Simply set the dangling pointer to null in the teardown_bar function in advance.

Can I submit a CVE for this? :)